### PR TITLE
fix: loading of media prevented - fix: duplication of rules for single sales-channel

### DIFF
--- a/src/Resources/views/page/robots/robots.txt.twig
+++ b/src/Resources/views/page/robots/robots.txt.twig
@@ -12,6 +12,8 @@
 
             {# Allow all theme files to be indexed, including the GET requests with the cache buster #}
             Allow: /*theme/
+            {# Allow all media files to be indexed, including the GET requests with the cache buster #}
+            Allow: /media/*?ts=
         {% endblock %}
 
         {% block frosh_robots_txt_content_disallow %}


### PR DESCRIPTION
- Commit c78f127 fixes crawling of media files. See https://forum.shopware.com/t/das-bild-kann-aufgrund-der-datei-robots-txt-nicht-gecrawlt-werden-google-merchants/104508 - my solution does explicitly not only allow the Googlebot but also other bots to crawl media files.
- Commit 3bf4cae1 fixes duplication of the sales-channel specific rules when multiple `SalesChannelDomains` with the same path exist. This commonly happens, when one domain is with HTTPS and one without.